### PR TITLE
fix: input validation in 3pool adapter constructor

### DIFF
--- a/contracts/adapters/CurveV1.sol
+++ b/contracts/adapters/CurveV1.sol
@@ -31,7 +31,7 @@ contract CurveV1Adapter is ICurvePool, ReentrancyGuard {
     /// @param _curvePool Address of curve-compatible pool
     constructor(address _creditManager, address _curvePool) {
         require(
-            _creditManager != address(0) && _creditManager != address(0),
+            _creditManager != address(0) && _curvePool != address(0),
             Errors.ZERO_ADDRESS_IS_NOT_ALLOWED
         );
         creditManager = ICreditManager(_creditManager);


### PR DESCRIPTION
Minor fix, but previously `_creditManager` was checked twice instead once.
Realistically the `address(0)` check on the `_creditManager` argument can be removed since we make a call in the constructor and since address(0) would not return anything, it would cause the constructor to revert (save some deployment gas). 